### PR TITLE
Update imagemagick.m4: augment PKG_CONFIG_PATH.

### DIFF
--- a/imagemagick.m4
+++ b/imagemagick.m4
@@ -123,7 +123,7 @@ AC_DEFUN([IM_FIND_IMAGEMAGICK],[
   AC_MSG_RESULT([found in $IM_WAND_BINARY])
 
 # This is used later for cflags and libs
-  export PKG_CONFIG_PATH="${IM_IMAGEMAGICK_PREFIX}/${PHP_LIBDIR}/pkgconfig"
+  export PKG_CONFIG_PATH="${IM_IMAGEMAGICK_PREFIX}/${PHP_LIBDIR}/pkgconfig:${PKG_CONFG_PATH}"
   
 # Check version
 #


### PR DESCRIPTION
Previously PKG_CONFIG_PATH was replaced on line 126.  This would lead to ./configure "forgetting" that it had found IM_WAND_BINARY through pkgconfig.  This augments the PATH, meaning we retain the previous result.